### PR TITLE
log the avail tags

### DIFF
--- a/lib/on_click_cell_factory.rb
+++ b/lib/on_click_cell_factory.rb
@@ -145,7 +145,8 @@ class OnClickCellFactory < Java::javafx::scene::control::TreeCell
               puts "Assuming the avail ID is the same as the inventory ID"
               id = the_tree_item.metric.id
             end
-            puts "Using ID [#{id}] for metric [#{the_tree_item.metric.name}]"
+            puts "Using ID [#{id}] for avail [#{the_tree_item.metric.name}]"
+            puts "Avail [#{id}] tags: #{::HawkHelper.metric_endpoint(the_tree_item.metric).get(id).tags}"
 
             ::HawkHelper.show_avail_popup stage, id
           else


### PR DESCRIPTION
The "show tags" UI option wasn't showing me tags. So this logs the tags via puts. This shows tags. There is a bug somewhere that the UI is failing to show tags for avail metrics.
