### PR TITLE
Reads inventory-metric-id property as hawkular-metric-id instead of m…

### DIFF
--- a/lib/chart_view_controller.rb
+++ b/lib/chart_view_controller.rb
@@ -51,7 +51,7 @@ class ChartViewController < Java::javafx::scene::layout::VBox
       series = xy_chart_series(name: metric.name)
 
       # if there is a metric-id property, use that as the ID, otherwise, use the instance ID itself
-      id = "#{metric.properties['metric-id']}"
+      id = "#{metric.properties['hawkular-metric-id']}"
       if id.to_s == ''
         puts 'Assuming the metric ID is the same as the inventory ID'
         id = metric.id

--- a/lib/on_click_cell_factory.rb
+++ b/lib/on_click_cell_factory.rb
@@ -100,7 +100,7 @@ class OnClickCellFactory < Java::javafx::scene::control::TreeCell
   def show_avail_popup(the_tree_item, tree_view)
     stage = tree_view.scene.window
 
-    id = "#{the_tree_item.raw_item.properties['metric-id']}"
+    id = "#{the_tree_item.raw_item.properties['hawkular-metric-id']}"
     if id.to_s == ''
       puts 'Assuming the avail ID is the same as the inventory ID'
       id = the_tree_item.raw_item.id


### PR DESCRIPTION
…etric-id.

I'll update this when we have a hawkular-client-ruby version that uses this property: (see: https://github.com/hawkular/hawkular-client-ruby/pull/140)