### PR TITLE
Reverse sort events/alerts by ctime

### DIFF
--- a/lib/alert_controller.rb
+++ b/lib/alert_controller.rb
@@ -87,7 +87,7 @@ class AlertController
     else
       alerts = Hawk.alerts.list_events 'startTime' => start
     end
-    alerts
+    alerts.sort_by { |a| a.ctime }.reverse!
   end
 
 end


### PR DESCRIPTION
I found it useful to have the events reverse sorted by time (newest being on top).
Before this, they weren't sorted at all, which was confusing.